### PR TITLE
Fix workflow triggers and safeguards

### DIFF
--- a/.github/workflows/build_on_upload.yml
+++ b/.github/workflows/build_on_upload.yml
@@ -3,8 +3,10 @@ name: Build content on upload
 on:
   push:
     paths:
-      - "incoming/**.pdf"
-      - "incoming/**.txt"
+      - "incoming/**/*.pdf"
+      - "incoming/**/*.PDF"
+      - "incoming/**/*.txt"
+      - "incoming/**/*.TXT"
 
 jobs:
   build:
@@ -18,6 +20,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Check required secrets
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::error::OPENAI_API_KEY secret is not set."
+            exit 1
+          fi
 
       - name: Install dependencies
         run: |
@@ -34,6 +45,10 @@ jobs:
         run: |
           git config user.name "auto-content-bot"
           git config user.email "bot@noreply.github.com"
-          git add content/
-          git commit -m "feat: auto-generated content"
-          git push
+          if [[ -n "$(git status --porcelain content/)" ]]; then
+            git add content/
+            git commit -m "feat: auto-generated content"
+            git push
+          else
+            echo "No changes to commit; skipping git push."
+          fi


### PR DESCRIPTION
## Summary
- trigger the build workflow for PDF and TXT uploads regardless of nested folders or uppercase extensions
- add an explicit check to fail fast when the OPENAI_API_KEY secret is missing
- skip the commit/push step gracefully when the content directory has no changes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cdde83ab88832ea124090d13120e09